### PR TITLE
reverse so basic install installs minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/converged-computing/kubescaler/tree/main) (0.0.x)
+ - default install should include all cloud deps (0.0.12)
  - GKE with ability to get kubernetes client (0.0.11)
  - support for AWS EKS and first versioned release (0.0.1)
  - initial skeleton release of project (0.0.0)

--- a/examples/aws/create-delete-cluster.py
+++ b/examples/aws/create-delete-cluster.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 import time
 
-from kubescaler.scaler import EKSCluster
+from kubescaler.scaler.aws import EKSCluster
 
 
 def get_parser():

--- a/examples/aws/test-scale.py
+++ b/examples/aws/test-scale.py
@@ -6,7 +6,7 @@ import os
 import sys
 import time
 
-from kubescaler.scaler import EKSCluster
+from kubescaler.scaler.aws import EKSCluster
 from kubescaler.utils import read_json
 
 # Save data here

--- a/examples/google/test-scale.py
+++ b/examples/google/test-scale.py
@@ -6,7 +6,7 @@ import os
 import sys
 import time
 
-from kubescaler.scaler import GKECluster
+from kubescaler.scaler.google import GKECluster
 from kubescaler.utils import read_json
 
 # Save data here

--- a/kubescaler/scaler/__init__.py
+++ b/kubescaler/scaler/__init__.py
@@ -1,2 +1,0 @@
-from .aws import EKSCluster
-from .google import GKECluster

--- a/kubescaler/version.py
+++ b/kubescaler/version.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (MIT)
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "kubescaler"

--- a/setup.py
+++ b/setup.py
@@ -90,10 +90,10 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         keywords=KEYWORDS,
         setup_requires=["pytest-runner"],
-        install_requires=INSTALL_REQUIRES,
+        install_requires=INSTALL_REQUIRES_ALL,
         tests_require=TESTS_REQUIRES,
         extras_require={
-            "all": [INSTALL_REQUIRES_ALL],
+            "basic": [INSTALL_REQUIRES],
             "google": INSTALL_REQUIRES_GOOGLE,
             "aws": INSTALL_REQUIRES_AWS,
         },


### PR DESCRIPTION
the default install should install all deps, as it is unlikely to want to use kubescaler in the basic (naked without any external providers) mode. An advanced user can still install the minimal needed for their cloud of choice.

This will close #4 