### PR TITLE
fix waiting for nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/converged-computing/kubescaler/tree/main) (0.0.x)
+ - remove dependency on subprocess and kubectl (0.0.13)
  - default install should include all cloud deps (0.0.12)
  - GKE with ability to get kubernetes client (0.0.11)
  - support for AWS EKS and first versioned release (0.0.1)

--- a/kubescaler/logger.py
+++ b/kubescaler/logger.py
@@ -189,7 +189,7 @@ def setup_logger(
     printshellcmds=False,
     nocolor=False,
     stdout=False,
-    debug=False,
+    debug=True,
     use_threads=False,
 ):
     # console output only if no custom logger was specified

--- a/kubescaler/scaler/aws/cluster.py
+++ b/kubescaler/scaler/aws/cluster.py
@@ -124,6 +124,7 @@ class EKSCluster(Cluster):
         It's best to be consistent and use an environment set (that ideally
         has a long enough expiration) OR just the $HOME/.aws/config.
         """
+        print("🥞️ Creating VPC stack and subnets...")
         self.set_vpc_stack()
         self.set_subnets()
 
@@ -131,6 +132,7 @@ class EKSCluster(Cluster):
         try:
             self.cluster = self.eks.describe_cluster(name=self.cluster_name)
         except Exception:
+            print("🥣️ Creating cluster...")
             self.cluster = self.new_cluster()
 
         # Get the status and confirm it's active
@@ -215,7 +217,7 @@ class EKSCluster(Cluster):
         """
         kubectl = self.get_k8s_client()
         while True:
-            print(f"Waiting for {self.node_count} nodes to be Ready...")
+            print(f"⏱️ Waiting for {self.node_count} nodes to be Ready...")
             time.sleep(5)
             nodes = kubectl.list_node()
             ready_count = 0
@@ -399,7 +401,6 @@ class EKSCluster(Cluster):
             TimeoutInMinutes=self.stack_timeout_minutes,
             OnFailure=self.on_stack_failure,
         )
-        print(self.stack_timeout_minutes)
         return self._create_stack(stack, self.workers_name)
 
     def new_cluster(self):

--- a/kubescaler/scaler/aws/cluster.py
+++ b/kubescaler/scaler/aws/cluster.py
@@ -112,7 +112,17 @@ class EKSCluster(Cluster):
     @timed
     def create_cluster(self):
         """
-        Create a cluster
+        Create a cluster.
+
+        To verify this is working, you should be able to view the Cloud Formation
+        in the console to see the VPC stack, and when that is complete, go to
+        EKS to see the cluster being created. When the cluster is created and
+        the nodes are up, the wait_for_nodes function should finish a little
+        bit after. If you don't see this happening, usually it means a mismatch
+        between the credentials you used to create the cluster, and the ones
+        that the AWS client discovers here (in token.py) to generate a token.
+        It's best to be consistent and use an environment set (that ideally
+        has a long enough expiration) OR just the $HOME/.aws/config.
         """
         self.set_vpc_stack()
         self.set_subnets()

--- a/kubescaler/scaler/aws/cluster.py
+++ b/kubescaler/scaler/aws/cluster.py
@@ -436,6 +436,7 @@ class EKSCluster(Cluster):
         except Exception:
             self.vpc_stack = self.create_vpc_stack()
 
+    @timed
     def create_vpc_stack(self):
         """
         Create a new stack from the template
@@ -610,6 +611,7 @@ class EKSCluster(Cluster):
         # Delete the VPC stack and we are done!
         logger.info("🥅️ Deleting VPC and associated assets...")
         self.delete_vpc_stack()
+        self.delete_worker_stack()
         logger.info("⭐️ Done!")
 
     @property

--- a/kubescaler/scaler/aws/token.py
+++ b/kubescaler/scaler/aws/token.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC and other
+# HPCIC DevTools Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (MIT)
+
+
+from datetime import datetime, timedelta
+
+from awscli.customizations.eks.get_token import (
+    TOKEN_EXPIRATION_MINS,
+    STSClientFactory,
+    TokenGenerator,
+)
+from botocore import session
+
+
+def get_expiration_time(expires_minutes=TOKEN_EXPIRATION_MINS):
+    token_expires = datetime.utcnow() + timedelta(minutes=expires_minutes)
+    return token_expires.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def get_bearer_token(
+    cluster_name: str, token_expire_minutes: int = None, role_arn: str = None
+) -> dict:
+    """
+    Create an STS session to generate a token for EKS
+    """
+    token_expire_minutes = token_expire_minutes or TOKEN_EXPIRATION_MINS
+    work_session = session.get_session()
+    client_factory = STSClientFactory(work_session)
+    sts_client = client_factory.get_sts_client(role_arn=role_arn)
+    token = TokenGenerator(sts_client).get_token(cluster_name)
+    return {
+        "kind": "ExecCredential",
+        "apiVersion": "client.authentication.k8s.io/v1alpha1",
+        "spec": {},
+        "status": {
+            "expirationTimestamp": get_expiration_time(token_expire_minutes),
+            "token": token,
+        },
+    }

--- a/kubescaler/version.py
+++ b/kubescaler/version.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (MIT)
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "kubescaler"


### PR DESCRIPTION
We currently rely on subprocess with eksctl, and this is not ideal for non-local environments (e.g., inside the flux operator). With this updated approach we instead generate a token with an STS handle, and instan- tiate an ApiClient configuration and pythonic kubectl.

I won't merge this until I've also tested it in the context of flux operator bursting!