### PR TITLE
allow for fine tuned timing and customization of node group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/converged-computing/kubescaler/tree/main) (0.0.x)
+ - allow manual customization and timing of nodegroup (e.g., for spot) (0.0.16)
  - extensive changes to aws client (thanks to @rajibhossen!) (0.0.15)
  - use api client with consistent token to associate nodes to cluster (0.0.14)
  - remove dependency on subprocess and kubectl (0.0.13)

--- a/kubescaler/scaler/aws/cluster.py
+++ b/kubescaler/scaler/aws/cluster.py
@@ -220,7 +220,7 @@ class EKSCluster(Cluster):
         # group name.
         self.wait_for_nodes()
         print(f"🦊️ Writing config file to {self.kube_config_file}")
-        print(f"  Usage: kubectl --kubeconfig={self.kube_config_file} get nodes")
+        print(f"   Usage: kubectl --kubeconfig={self.kube_config_file} get nodes")
         return self.cluster
 
     def load_cluster_info(self):
@@ -315,7 +315,7 @@ class EKSCluster(Cluster):
         start = time.time()
         kubectl = self.get_k8s_client()
         while True:
-            print(f"⏱️ Waiting for {self.node_count} nodes to be Ready...")
+            print(f"⏱️  Waiting for {self.node_count} nodes to be Ready...")
             time.sleep(5)
             nodes = kubectl.list_node()
             ready_count = 0
@@ -398,6 +398,9 @@ class EKSCluster(Cluster):
         try:
             k8sutils.create_from_yaml(kubectl.api_client, self.auth_config_file)
         except Exception as e:
+            # Don't print the "this already exists error" we might be re-using it
+            if "already exists" in str(e):
+                pass
             print(f"😭️ Kubectl create from yaml returns in error: {e}")
 
     def ensure_kube_config(self):

--- a/kubescaler/scaler/aws/cluster.py
+++ b/kubescaler/scaler/aws/cluster.py
@@ -1046,7 +1046,7 @@ class EKSCluster(Cluster):
                 clusterName=self.cluster_name, nodegroupName=self.node_group_name
             )
         except Exception:
-            logger.warning(f"✖️ Node Group {nodegroup_name} does not exist.")
+            logger.warning(f"✖️  Node Group {nodegroup_name} does not exist.")
             return
 
         try:

--- a/kubescaler/version.py
+++ b/kubescaler/version.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (MIT)
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "kubescaler"


### PR DESCRIPTION
This will allow us to run more fine tuned experiments that just test creating and deleting nodegroups, ensuring we time them appropriately. The context here is creating and deleting different requests for spot instance groups, which I'm setting up now.