### PR TITLE
allow aws eks cluster to have multiple node groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/converged-computing/kubescaler/tree/main) (0.0.x)
+ - support adding one-off node groups to a cluster (0.0.17)
  - allow manual customization and timing of nodegroup (e.g., for spot) (0.0.16)
  - extensive changes to aws client (thanks to @rajibhossen!) (0.0.15)
  - use api client with consistent token to associate nodes to cluster (0.0.14)

--- a/kubescaler/version.py
+++ b/kubescaler/version.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: (MIT)
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"
 AUTHOR = "Vanessa Sochat"
 EMAIL = "vsoch@users.noreply.github.com"
 NAME = "kubescaler"


### PR DESCRIPTION
We are doing experiments with spot instances, and it is a very bad idea to install operators to spot nodes that are going to be destroyed. Instead I am testing the ability to create a one-off node group (also associated with the cluster) that could run a persistent (smaller) node for the operators

This is a WIP in that I'm not sure it will work (testing now)!

Update - worked great!